### PR TITLE
Fix background colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.0
+# 0.2.1
 
 * Compliance with the tldr spec
 * Fix `--update` flag bug

--- a/src/Tldr.hs
+++ b/src/Tldr.hs
@@ -24,7 +24,6 @@ data ConsoleSetting = ConsoleSetting
   , fgIntensity :: ColorIntensity
   , fgColor :: Color
   , bgIntensity :: ColorIntensity
-  , bgColor :: Color
   , consoleIntensity :: ConsoleIntensity
   }
 
@@ -37,7 +36,6 @@ defConsoleSetting =
   , fgIntensity = Dull
   , fgColor = White
   , bgIntensity = Dull
-  , bgColor = Black
   , consoleIntensity = NormalIntensity
   }
 
@@ -54,7 +52,6 @@ toSGR cons =
   , SetUnderlining (underline cons)
   , SetBlinkSpeed (blink cons)
   , SetColor Foreground (fgIntensity cons) (fgColor cons)
-  , SetColor Background (bgIntensity cons) (bgColor cons)
   ]
 
 renderNode :: NodeType -> IO ()


### PR DESCRIPTION
So I'm using *solarized-light* color scheme, and for me it looks like this:

![](http://i.imgur.com/zaQSySS.png)

After this fix, it looks right:

![](http://i.imgur.com/Xz9dLcr.png)

I also test it with a dark background, and it works fine:

![](http://i.imgur.com/dCERlfQ.png)


Making `fgColor = Black` and `bgColor = White` wouldn't work, the reason is that what the terminal's color pallette `white` is, may or may not be what the background color is. So the result ends up looking wrong again:

![](http://i.imgur.com/ngNi8pY.png)

I can't think of a case on which one would like to have the background of the printed out text to be different to the terminal's background color, hence the fix.
