### PR TITLE
Reset terminal at the end of `handleNode`

### DIFF
--- a/src/Tldr.hs
+++ b/src/Tldr.hs
@@ -86,6 +86,7 @@ handleNode (Node _ ntype xs) = do
   changeConsoleSetting ntype
   renderNode ntype
   mapM_ (\(Node _ ntype' ns) -> renderNode ntype' >> mapM_ handleNode ns) xs
+  setSGR [Reset]
 
 parsePage :: FilePath -> IO Node
 parsePage fname = do


### PR DESCRIPTION
Hey,

thank you for this haskell tldr client.

I've experienced colour issues in my terminal:
<img width="606" alt="screen shot 2017-11-26 at 23 43 36" src="https://user-images.githubusercontent.com/17603372/33245740-b13bee32-d303-11e7-84d1-4a53a516451c.png">

My PR fixes this:
<img width="597" alt="screen shot 2017-11-26 at 23 44 38" src="https://user-images.githubusercontent.com/17603372/33245754-cb1c95f4-d303-11e7-80a0-04342dc891c3.png">

Feel free to merge or let me know if you're not happy with this.
