### PR TITLE
Reimplement shell interfacing with API from the "typed-process" package

### DIFF
--- a/tldr.cabal
+++ b/tldr.cabal
@@ -33,7 +33,7 @@ executable tldr
                      , optparse-applicative
                      , directory
                      , filepath
-                     , shell-conduit >= 4.6.0
+                     , typed-process >= 0.2
                      , semigroups
   default-language:    Haskell2010
 


### PR DESCRIPTION
Hi!

As you suggested, I re-implemented shell interfacing with `typed-process` API. The resulting app works well on both Ubuntu16 and Win10. I do not have access to MacOS to test there, but in theory all commands that I use are available there as well.

Cheers!