### PR TITLE
Remove duplicate initialisation checks

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -40,7 +40,6 @@ tldrInitialized = do
 initializeTldrPages :: IO ()
 initializeTldrPages = do
   initialized <- tldrInitialized
-  initialized <- tldrInitialized
   unless initialized $ do
     homeDir <- getHomeDirectory
     let cloneDir = homeDir </> tldrDirName


### PR DESCRIPTION
`initializeTldrPages`, in `app/Main.hs`, contains two sequential initialisation checks (calls to `tldrInitialized`):
```haskell
initializeTldrPages :: IO ()
initializeTldrPages = do
  initialized <- tldrInitialized
  initialized <- tldrInitialized
  unless initialized $ do
    homeDir <- getHomeDirectory
    let cloneDir = homeDir </> tldrDirName
    runProcess_ $ proc "mkdir" [cloneDir]
    runProcess_ $ setWorkingDir cloneDir $ proc "git" ["clone", repoHttpsUrl]
```
I was very confused as to why this is necessary and have come to the conclusion that it is a simple typo. Hence, the goal of this PR is to improve the comprehensibility of this function's definition by removing the duplicate initialisation check. The result is:
```haskell
initializeTldrPages :: IO ()
initializeTldrPages = do
  initialized <- tldrInitialized
  unless initialized $ do
    homeDir <- getHomeDirectory
    let cloneDir = homeDir </> tldrDirName
    runProcess_ $ proc "mkdir" [cloneDir]
    runProcess_ $ setWorkingDir cloneDir $ proc "git" ["clone", repoHttpsUrl]
```
This successfully compiles and runs on my Ubuntu `18.04.1` machine, with stack `1.7.1`.