### PR TITLE
Add windows to checkDirs

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -26,7 +26,7 @@ repoHttpsUrl :: String
 repoHttpsUrl = "https://github.com/tldr-pages/tldr.git"
 
 checkDirs :: [String]
-checkDirs = ["common", "linux", "osx"]
+checkDirs = ["common", "linux", "osx", "windows"]
 
 tldrInitialized :: IO Bool
 tldrInitialized = do
@@ -84,14 +84,15 @@ getPagePath :: String -> IO (Maybe FilePath)
 getPagePath page = do
   homeDir <- getHomeDirectory
   let pageDir = homeDir </> tldrDirName </> "tldr" </> "pages"
-      x@(f1:f2:f3:[]) = map (\x -> pageDir </> x </> page <.> "md") checkDirs
+      x@(f1:f2:f3:f4:[]) = map (\x -> pageDir </> x </> page <.> "md") checkDirs
 #if MIN_VERSION_base(4,7,0)
   f1' <- pageExists f1
   f2' <- pageExists f2
   f3' <- pageExists f3
-  return $ f1' <|> f2' <|> f3'
+  f4' <- pageExists f4
+  return $ f1' <|> f2' <|> f3' <|> f4'
 #else
-  pageExists f1 <|> pageExists f2 <|> pageExists f3
+  pageExists f1 <|> pageExists f2 <|> pageExists f3 <|> pageExists f4
 #endif
 
 


### PR DESCRIPTION
# The problem
I noticed that [`checkDirs`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs#L28) (in [`app/Main.hs`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs)) only contains the [`common`](https://github.com/tldr-pages/tldr/tree/master/pages/windows), [`linux`](https://github.com/tldr-pages/tldr/tree/master/pages/windows) and [`osx`](https://github.com/tldr-pages/tldr/tree/master/pages/windows) directories, but not the [`windows`](https://github.com/tldr-pages/tldr/tree/master/pages/windows) directory:
```haskell
checkDirs :: [String]
checkDirs = ["common", "linux", "osx"]
```
However, both `stack` and `ghc` have support for Windows; even though `tldr-hs` will compile on Windows, it won't use the Windows specific pages.
This PR aims to solve that problem.

# The solution
The result is changing [`checkDirs`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs#L28) from it's previously stated definition to:
```haskell
checkDirs :: [String]
checkDirs = ["common", "linux", "osx", "windows"]
```
and changing [`getPagePath`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs#L83), from:
```haskell
getPagePath :: String -> IO (Maybe FilePath)
getPagePath page = do
  homeDir <- getHomeDirectory
  let pageDir = homeDir </> tldrDirName </> "tldr" </> "pages"
      x@(f1:f2:f3:[]) = map (\x -> pageDir </> x </> page <.> "md") checkDirs
#if MIN_VERSION_base(4,7,0)
  f1' <- pageExists f1
  f2' <- pageExists f2
  f3' <- pageExists f3
  return $ f1' <|> f2' <|> f3'
#else
  pageExists f1 <|> pageExists f2 <|> pageExists f3
#endif
```
to:
```haskell
getPagePath :: String -> IO (Maybe FilePath)
getPagePath page = do
  homeDir <- getHomeDirectory
  let pageDir = homeDir </> tldrDirName </> "tldr" </> "pages"
      x@(f1:f2:f3:f4:[]) = map (\x -> pageDir </> x </> page <.> "md") checkDirs
#if MIN_VERSION_base(4,7,0)
  f1' <- pageExists f1
  f2' <- pageExists f2
  f3' <- pageExists f3
  f4' <- pageExists f4
  return $ f1' <|> f2' <|> f3' <|> f4'
#else
  pageExists f1 <|> pageExists f2 <|> pageExists f3 <|> pageExists f4
#endif
```

# Status
This solution works perfectly fine on my `Ubuntu 18.04.1` machine:
```fish
> tldr assoc
assoc
Display or modify file extension associations.

 - Display all associated filetypes:
   assoc

 - Display the associated filetype for a specific extension:
   assoc {{.txt}}

 - Modify the associated filetype for a specific extension:
   assoc {{.txt}}={{txtfile}}
> tldr cls
cls
Clears the screen.

 - Clear the screen:
   cls
> tldr adduser
adduser
User addition utility.

 - Create a new user with a default home directory and prompt the user to set a password:
   adduser {{username}}

 - Create a new user without a home directory:
   adduser --no-create-home {{username}}

 - Create a new user with a home directory at the specified path:
   adduser --home {{path/to/home}} {{username}}

 - Create a new user with the specified shell set as the login shell:
   adduser --shell {{path/to/shell}} {{username}}

 - Create a new user belonging to the specified group:
   adduser --ingroup {{group}} {{username}}
```
(both [`assoc`](https://github.com/tldr-pages/tldr/blob/master/pages/windows/assoc.md) and [`cls`](https://github.com/tldr-pages/tldr/blob/master/pages/windows/cls.md) are in the [`windows` pages directory](https://github.com/tldr-pages/tldr/tree/master/pages/windows); [`adduser`](https://github.com/tldr-pages/tldr/blob/master/pages/linux/adduser.md) is merely used to show that pages from other directories still load).