### PR TITLE
Improve getPagePath

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -84,7 +84,7 @@ getPagePath page = do
   homeDir <- getHomeDirectory
   let pageDir = homeDir </> tldrDirName </> "tldr" </> "pages"
       paths = map (\x -> pageDir </> x </> page <.> "md") checkDirs
-  foldr (<|>) Nothing <$> mapM pageExists paths
+  foldr1 (<|>) <$> mapM pageExists paths
 
 main :: IO ()
 main = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,3 @@
-{-#LANGUAGE CPP#-}
 {-#LANGUAGE ScopedTypeVariables#-}
 
 module Main where
@@ -84,17 +83,8 @@ getPagePath :: String -> IO (Maybe FilePath)
 getPagePath page = do
   homeDir <- getHomeDirectory
   let pageDir = homeDir </> tldrDirName </> "tldr" </> "pages"
-      x@(f1:f2:f3:f4:[]) = map (\x -> pageDir </> x </> page <.> "md") checkDirs
-#if MIN_VERSION_base(4,7,0)
-  f1' <- pageExists f1
-  f2' <- pageExists f2
-  f3' <- pageExists f3
-  f4' <- pageExists f4
-  return $ f1' <|> f2' <|> f3' <|> f4'
-#else
-  pageExists f1 <|> pageExists f2 <|> pageExists f3 <|> pageExists f4
-#endif
-
+      paths = map (\x -> pageDir </> x </> page <.> "md") checkDirs
+  foldr (<|>) Nothing <$> mapM pageExists paths
 
 main :: IO ()
 main = do


### PR DESCRIPTION
# The problem
The definition of [`Main.getPagePath`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs#L83) is dependant on the length of [`Main.checkDirs`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs#L28):
```haskell
getPagePath :: String -> IO (Maybe FilePath)
getPagePath page = do
  homeDir <- getHomeDirectory
  let pageDir = homeDir </> tldrDirName </> "tldr" </> "pages"
      x@(f1:f2:f3:f4:[]) = map (\x -> pageDir </> x </> page <.> "md") checkDirs
#if MIN_VERSION_base(4,7,0)
  f1' <- pageExists f1
  f2' <- pageExists f2
  f3' <- pageExists f3
  f4' <- pageExists f4
  return $ f1' <|> f2' <|> f3' <|> f4'
#else
  pageExists f1 <|> pageExists f2 <|> pageExists f3 <|> pageExists f4
#endif
```
This over complicates the process of adding new directories to [`Main.checkDirs`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs#L28).
# The solution
Modify [`Main.getPagePath`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs#L83)'s definition to take advantage of `Control.Monad`'s utilities. The result is:
```haskell
getPagePath :: String -> IO (Maybe FilePath)
getPagePath page = do
  homeDir <- getHomeDirectory
  let pageDir = homeDir </> tldrDirName </> "tldr" </> "pages"
      paths = map (\x -> pageDir </> x </> page <.> "md") checkDirs
  foldr (<|>) Nothing <$> mapM pageExists paths
```
> NOTE: I also disabled the `CPP` language extension, as, [`Main.getPagePath`](https://github.com/psibi/tldr-hs/blob/master/app/Main.hs#L83) was the only function dependant `CPP`.
# Status
This solution successfully compiles and runs on my `Ubuntu 18.04.1` machine, with `stack 1.7.1`.