### PR TITLE
When updating the database, show the download location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.1
+
+* When pages are updated, the client now shows the download location.
+
 # 0.8.0
 
 * Split the library into more parts.

--- a/src/Tldr/App/Handler.hs
+++ b/src/Tldr/App/Handler.hs
@@ -92,8 +92,10 @@ updateTldrPages = do
   let repoDir = dataDir </> "tldr"
   repoExists <- doesDirectoryExist repoDir
   if repoExists
-    then runProcess_ $
-         setWorkingDir repoDir $ proc "git" ["pull", "origin", "master"]
+    then do
+         putStrLn $ "Downloading tldr pages to " ++ repoDir
+         runProcess_ $
+            setWorkingDir repoDir $ proc "git" ["pull", "origin", "master"]
     else initializeTldrPages
 
 computeLocale :: Maybe String -> Locale
@@ -137,6 +139,7 @@ initializeTldrPages = do
   unless initialized $ do
     dataDir <- getXdgDirectory XdgData tldrDirName
     createDirectoryIfMissing False dataDir
+    putStrLn $ "Initialising tldr page storage in " ++ dataDir
     runProcess_ $ setWorkingDir dataDir $ proc "git" ["clone", repoHttpsUrl]
 
 getCheckDirs :: ViewOptions -> [String]


### PR DESCRIPTION
As a user, the location of the tldr pages on disk is very intransparent. I tried to change that. Adding a logging framework and using that seemed overkill, so I stuck to using `putStrLn`