### PR TITLE
auto update is only available in new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ regularly update the cache.  Such an update can be run manually with:
 $ tldr --update
 ```
 
-Users of this client can enable automatic updates by running it with
-the option `--auto-update-interval DAYS` specified.  The client will
-then check whether the cached version of the tldr pages is older than
-`DAYS` days and perform an update in that case.  To enable this
-functionality permanently, users can put the line `alias tldr="tldr
---auto-update-interval DAYS"` in their shell configuration file
-(e.g. `.bashrc`, `.zshrc`) with the desired update interval specified.
+Starting with version `0.9.0`, users of this client can enable automatic 
+updates by running it with the option `--auto-update-interval DAYS`
+specified.  The client will then check whether the cached version of the
+tldr pages is older than `DAYS` days and perform an update in that case. 
+To enable this functionality permanently, users can put the line
+`alias tldr="tldr --auto-update-interval DAYS"` in their shell 
+configuration file (e.g. `.bashrc`, `.zshrc`) with the desired update
+interval specified.
 
 ## Snapshot
 


### PR DESCRIPTION
I use `tldr` on ubuntu 20.10 and it comes 0.6.4. Having such an old (?) version in ubuntu probably makes the old version quite prominent across the world. Therefore, I think it would be good to hint that the auto update feature is only available in the new version.

Note that I only added a prefix to that paragraph, but due to the line length, I had to move more text.