### PR TITLE
Update main URL to latest TLDR releases

### DIFF
--- a/src/Tldr/App/Constant.hs
+++ b/src/Tldr/App/Constant.hs
@@ -4,7 +4,7 @@ tldrDirName :: String
 tldrDirName = "tldr"
 
 pagesUrl :: String
-pagesUrl = "https://tldr.sh/assets/tldr.zip"
+pagesUrl = "https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip"
 
 checkDirs :: [String]
 checkDirs = "common" : platformDirs


### PR DESCRIPTION
`https://tldr.sh/assets/tldr.zip` is no longer the canonical source for tldr pages. The official distribution is now on GitHub releases.

- **`src/Tldr/App/Constant.hs`**: Update `pagesUrl`

```haskell
-- Before
pagesUrl = "https://tldr.sh/assets/tldr.zip"

-- After
pagesUrl = "https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip"
```

Did not compile but the URL does fetch the zip file.